### PR TITLE
Allow username to be displayed along the text messages posted

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -16,7 +16,10 @@
             <div id="messages" class="chat__messages"></div>
             <div class="compose">
                 <form>
-                    <input placeholder="message" type="text" name="messageToBeSent" id="messageToBeSent">
+                    <input placeholder="message" type="text" 
+                            name="messageToBeSent" 
+                            id="messageToBeSent" 
+                            required autocomplete="off">
                     <button id="sendMessageBtn">Send</button>
                 </form>
                 <button id="share-location">share location</button>
@@ -26,7 +29,7 @@
     <script id="message-template" type="text/html">
         <div class="message">
             <p>
-                <span class="message__name">Some User Name</span>
+                <span class="message__name">{{username}}</span>
                 <span class="message__meta">{{createdAt}}</span>
             </p>
             <p> {{message}}</p>

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -16,6 +16,7 @@ const socket = io()
 socket.on('message', (message) => {
     console.log(message)
     const html = Mustache.render(messageTemplate, { 
+        username: message.username,
         message: message.text,
         createdAt: moment(message.createdAt).format('h:mm a')
      })

--- a/src/index.js
+++ b/src/index.js
@@ -32,15 +32,6 @@ io.on('connection', (socket) => {
         callback()
     })
     
-    /**
-     * Goals: Render username for text messages
-     * 
-     * 1. Setup the server to send username to client
-     * 2. Edit every call to "generateMessage" to include username
-     *    - Use "Admin" for sys messages like connect/welcome/disconnect
-     * 3. Update the client to render username in template
-     * 4. Test your work
-     */
     socket.on('sendMessage', (message, callback) => {
         const user = getUser(socket.id)
         console.log(' inside sendMessage listener' + user)

--- a/src/index.js
+++ b/src/index.js
@@ -27,12 +27,20 @@ io.on('connection', (socket) => {
             return callback(error)
         }
         socket.join(user.room)
-        socket.emit('message', generateMessage('Welcome!'))
-        socket.broadcast.to(user.room).emit('message', generateMessage(`${user.username} has joined`))
+        socket.emit('message', generateMessage('Admin','Welcome!'))
+        socket.broadcast.to(user.room).emit('message', generateMessage('Admin',`${user.username} has joined`))
         callback()
     })
     
-    
+    /**
+     * Goals: Render username for text messages
+     * 
+     * 1. Setup the server to send username to client
+     * 2. Edit every call to "generateMessage" to include username
+     *    - Use "Admin" for sys messages like connect/welcome/disconnect
+     * 3. Update the client to render username in template
+     * 4. Test your work
+     */
     socket.on('sendMessage', (message, callback) => {
         const user = getUser(socket.id)
         console.log(' inside sendMessage listener' + user)
@@ -40,7 +48,7 @@ io.on('connection', (socket) => {
         if (filter.isProfane(message)) {
             return callback('Profanity is not allowed!')
         }
-        io.to(user.room).emit('message', generateMessage(message))
+        io.to(user.room).emit('message', generateMessage(user.username, message))
         callback()
     })
 
@@ -54,7 +62,7 @@ io.on('connection', (socket) => {
     socket.on('disconnect', () => {
         const user = removeUser(socket.id)
         if (user) {
-            io.to(user.room).emit('message', generateMessage(`${user.username} has left!`))
+            io.to(user.room).emit('message', generateMessage('Admin',`${user.username} has left!`))
         }
     })
 

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -1,5 +1,6 @@
-const generateMessage = (text) => {
+const generateMessage = (username, text) => {
     return {
+        username,
         text,
         createdAt: new Date().getTime()
     } 


### PR DESCRIPTION
in src/utils/messages.js modified the generateMessage function to include the username
in src/index.js, changed generateMessage to include the username
in public/js/chat.js include the username as part of the data to be rendered in the template
in public/chat.html include the username in the message template.

closes #24 